### PR TITLE
ci: adopt the standard commands and jobs from the toolkit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ parameters:
   min-rust-version:
     type: string
     default: "1.75"
+  fingerprint:
+    type: string
+    default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg
 
 orbs:
   toolkit: jerus-org/circleci-toolkit@0.5.0
@@ -111,6 +114,7 @@ workflows:
             - test-suite
           context:
             - release
+          ssh_fingerprint: << pipeline.parameters.fingerprint >>
 
   release:
     when:
@@ -121,3 +125,4 @@ workflows:
       - toolkit/make_release:
           context:
             - release
+          ssh_fingerprint: << pipeline.parameters.fingerprint >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,52 +5,21 @@ parameters:
     type: string
     default: "1.75"
 
+orbs:
+  toolkit: jerus-org/circleci-toolkit@0.5.0
+
 executors:
   rust-env:
     docker:
       - image: jerusdp/ci-rust:<<pipeline.parameters.min-rust-version>>
 
 commands:
-  cargo-build:
-    parameters:
-      rust-version:
-        default: "stable"
-        type: string
-    steps:
-      - run:
-          name: Check build <<parameters.rust-version>>
-          command: |
-            cargo +<<parameters.rust-version>> check --all-features --workspace --examples
-
   cargo-docs:
     steps:
       - run:
           name: Generate the crate documentation
           command: |
             cargo +nightly doc --lib --no-deps --all-features --document-private-items
-
-  gpg-key:
-    steps:    
-      - run:
-          name: import GPG key
-          command: |
-            echo -e $BOT_GPG_KEY \
-              | base64 --decode --ignore-garbage \
-              | gpg --batch --allow-secret-key-import --import 
-            gpg --fingerprint
-            echo $BOT_TRUST | gpg --import-ownertrust
-            gpg --fingerprint
-
-  git-config:
-    steps:
-      - run:
-          name: Configure git for user and signing
-          command: |
-            git config --global user.email "$BOT_USER_EMAIL"
-            git config --global user.name "$BOT_USER_NAME"
-            git config --global gpg.program gpg
-            git config --global user.signingkey "$BOT_SIGN_KEY"
-            git config --global commit.gpgsign true
 
 jobs:
   rust-versions:
@@ -63,34 +32,21 @@ jobs:
     steps:
       - checkout
       - run: cargo --version
-      - cargo-build
-      - cargo-build:
-          rust-version: "stable"
-      - cargo-build:
-          rust-version: <<pipeline.parameters.min-rust-version>>
+      - toolkit/cargo_build
+      - toolkit/cargo_build:
+          rust_version: "stable"
+      - toolkit/cargo_build:
+          rust_version: <<pipeline.parameters.min-rust-version>>
 
   optional-builds:
     executor: rust-env
     steps:
       - checkout
       - run: cargo --version
-      - cargo-build
-      - cargo-build:
-          rust-version: "nightly"
-      - cargo-build:
-          rust-version: "beta"
-
-  basic-tests:
-    parameters:
-      basic-test:
-        type: string
-    executor: rust-env
-    steps:
-      - checkout
-      - run: cargo +stable --version
-      - run:
-          name: Running basic test <<parameters.basic-test>>
-          command: <<parameters.basic-test>>
+      - toolkit/cargo_build:
+          rust_version: "nightly"
+      - toolkit/cargo_build:
+          rust_version: "beta"
 
   test-suite:
     parameters:
@@ -112,72 +68,6 @@ jobs:
       - checkout
       - cargo-docs
 
-  pr-changelog-update:
-    executor: rust-env
-    steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints: 
-            - SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg
-      - run:
-          name: Remove original SSH key from agent 
-          command: |
-            ssh-add -l
-            ssh-add -d ~/.ssh/id_rsa.pub
-            ssh-add -l
-      - gpg-key
-      - git-config
-      - run:
-          name: Update changelog
-          command: |
-            pcu -vv
-
-  release-ready:
-    executor: rust-env
-    steps:
-      - checkout
-      - run:
-          name: Check if ready to make a release
-          command: |
-            set -eo pipefail
-
-            if [ "$(nextsv -q)" != "none" ]
-            then
-              exit 0
-            else 
-             exit 1
-            fi
-
-  make-release:
-    executor: rust-env
-    steps:
-      - checkout
-      - run:
-          name: import GPG key
-          command: |
-            echo -e $GPGKEY \
-              | base64 --decode --ignore-garbage \
-              | gpg --batch --allow-secret-key-import --import 
-            gpg --keyid-format  LONG --list-secret-keys
-      - run:
-          name: Configure git for user and signing
-          command: |
-            git config user.email "$USER_EMAIL"
-            git config user.name "$USER_NAME"
-            git config --global gpg.program gpg
-            git config --global user.signingkey "$SIGNKEY"
-      - run:
-          name: Publish update
-          command: |
-            set -exo pipefail
-            export NEXTSV_LEVEL=$(nextsv -q -c other require -f CHANGES.md -f CHANGELOG.md feature)
-            if [ $NEXTSV_LEVEL != "none" ] ; then 
-              cargo release changes
-              cargo release -vvv --execute --no-confirm --sign-tag "$NEXTSV_LEVEL"
-            else 
-              echo "Not ready to release yet."
-            fi
-
 workflows:
   validation:
     when:
@@ -187,16 +77,17 @@ workflows:
       - rust-versions
       - required-builds
       - optional-builds
-      - basic-tests:
-          matrix:
-            parameters:
-              basic-test:
-                [
-                  cargo +stable fmt --all -- --check,
-                  cargo +stable clippy --workspace --examples --tests --all-features -- -D warnings,
-                  cargo +stable test -p hcaptcha --lib,
-                  cargo +stable test -p hcaptcha --doc,
-                ]
+      - toolkit/common_tests
+      # - basic-tests:
+      #     matrix:
+      #       parameters:
+      #         basic-test:
+      #           [
+      #             cargo +stable fmt --all -- --check,
+      #             cargo +stable clippy --workspace --examples --tests --all-features -- -D warnings,
+      #             cargo +stable test -p hcaptcha --lib,
+      #             cargo +stable test -p hcaptcha --doc,
+      #           ]
       - test-suite:
           matrix:
             parameters:
@@ -210,11 +101,12 @@ workflows:
                   test_suite_enterprise,
                 ]
           requires:
-            - basic-tests
+            # - basic-tests
+            - toolkit/common_tests
             - required-builds
             - docs
       - docs
-      - pr-changelog-update:
+      - toolkit/update_changelog:
           requires:
             - test-suite
           context:
@@ -226,9 +118,6 @@ workflows:
         - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - equal: ["release check", << pipeline.schedule.name >>]
     jobs:
-      - release-ready
-      - make-release:
-          requires:
-            - release-ready
+      - toolkit/make_release:
           context:
             - release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,15 @@ workflows:
   validation:
     when:
       not:
-        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        or:
+          [
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>],
+            equal:
+              [
+                ci_bot,
+                << pipeline.trigger_parameters.github_app.user_username. >>,
+              ],
+          ]
     jobs:
       - rust-versions
       - required-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,8 @@ jobs:
           name: Check if last commit made by bot
           command: |
             committer=$(git log -1 HEAD --pretty=format:%cn)
-            if [[ $committer == << parameters.bot-name >> ]]; then
+            echo $committer
+            if [[ "$committer" == "<< parameters.bot-name >>" ]]; then
             curl --request POST \
               --url https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel \
               --header "Circle-Token: ${CIRCLE_TOKEN}"
@@ -107,6 +108,9 @@ workflows:
           requires:
             - check-for-bot
       - toolkit/common_tests:
+          requires:
+            - check-for-bot
+      - docs:
           requires:
             - check-for-bot
 
@@ -137,7 +141,6 @@ workflows:
             - toolkit/common_tests
             - required-builds
             - docs
-      - docs
       - toolkit/update_changelog:
           requires:
             - test-suite

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
           [
             equal: [scheduled_pipeline, << pipeline.trigger_source >>],
             equal:
-              [ci_bot, << pipeline.trigger_parameters.github_app.user_name. >>],
+              [ci_bot, << pipeline.trigger_parameters.github_app.user_name >>],
           ]
     jobs:
       - rust-versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,8 +96,7 @@ workflows:
       not:
         equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
-      - check-for-bot:
-          bot-name: jerus-bot
+      - check-for-bot
       - rust-versions:
           requires:
             - check-for-bot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,12 +92,7 @@ workflows:
   validation:
     when:
       not:
-        or:
-          [
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>],
-            equal:
-              [ci_bot, << pipeline.trigger_parameters.github_app.user_name >>],
-          ]
+        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - check-for-bot:
           bot-name: jerus-bot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,23 @@ jobs:
       - checkout
       - cargo-docs
 
+  check-for-bot:
+    executor: rust-env
+    parameters:
+      bot-name:
+        type: string
+        default: jerus-bot
+        description: The name of the bot to check for
+    steps:
+      - checkout
+      - run: |
+          committer=$(git log -1 HEAD --pretty=format:%cn)
+          if [[ $committer == << parameters.bot-name >> ]]; then
+          curl --request POST \
+            --url https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel \
+            --header "Circle-Token: ${CIRCLE_TOKEN}"
+          fi
+
 workflows:
   validation:
     when:
@@ -82,10 +99,21 @@ workflows:
               [ci_bot, << pipeline.trigger_parameters.github_app.user_name >>],
           ]
     jobs:
-      - rust-versions
-      - required-builds
-      - optional-builds
-      - toolkit/common_tests
+      - check-for-bot:
+          bot-name: jerus-bot
+      - rust-versions:
+          requires:
+            - check-for-bot
+      - required-builds:
+          requires:
+            - check-for-bot
+      - optional-builds:
+          requires:
+            - check-for-bot
+      - toolkit/common_tests:
+          requires:
+            - check-for-bot
+
       # - basic-tests:
       #     matrix:
       #       parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,17 +76,19 @@ jobs:
     parameters:
       bot-name:
         type: string
-        default: jerus-bot
+        default: "Jerus Bot"
         description: The name of the bot to check for
     steps:
       - checkout
-      - run: |
-          committer=$(git log -1 HEAD --pretty=format:%cn)
-          if [[ $committer == << parameters.bot-name >> ]]; then
-          curl --request POST \
-            --url https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel \
-            --header "Circle-Token: ${CIRCLE_TOKEN}"
-          fi
+      - run:
+          name: Check if last commit made by bot
+          command: |
+            committer=$(git log -1 HEAD --pretty=format:%cn)
+            if [[ $committer == << parameters.bot-name >> ]]; then
+            curl --request POST \
+              --url https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel \
+              --header "Circle-Token: ${CIRCLE_TOKEN}"
+            fi
 
 workflows:
   validation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,7 @@ workflows:
           [
             equal: [scheduled_pipeline, << pipeline.trigger_source >>],
             equal:
-              [
-                ci_bot,
-                << pipeline.trigger_parameters.github_app.user_username. >>,
-              ],
+              [ci_bot, << pipeline.trigger_parameters.github_app.user_name. >>],
           ]
     jobs:
       - rust-versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
     default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@0.5.0
+  toolkit: jerus-org/circleci-toolkit@0.6.0
 
 executors:
   rust-env:
@@ -71,25 +71,25 @@ jobs:
       - checkout
       - cargo-docs
 
-  check-for-bot:
-    executor: rust-env
-    parameters:
-      bot-name:
-        type: string
-        default: "Jerus Bot"
-        description: The name of the bot to check for
-    steps:
-      - checkout
-      - run:
-          name: Check if last commit made by bot
-          command: |
-            committer=$(git log -1 HEAD --pretty=format:%cn)
-            echo $committer
-            if [[ "$committer" == "<< parameters.bot-name >>" ]]; then
-            curl --request POST \
-              --url https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel \
-              --header "Circle-Token: ${CIRCLE_TOKEN}"
-            fi
+  # check-for-bot:
+  #   executor: rust-env
+  #   parameters:
+  #     bot-name:
+  #       type: string
+  #       default: "Jerus Bot"
+  #       description: The name of the bot to check for
+  #   steps:
+  #     - checkout
+  #     - run:
+  #         name: Check if last commit made by bot
+  #         command: |
+  #           committer=$(git log -1 HEAD --pretty=format:%cn)
+  #           echo $committer
+  #           if [[ "$committer" == "<< parameters.bot-name >>" ]]; then
+  #           curl --request POST \
+  #             --url https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel \
+  #             --header "Circle-Token: ${CIRCLE_TOKEN}"
+  #           fi
 
 workflows:
   validation:
@@ -97,7 +97,8 @@ workflows:
       not:
         equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
-      - check-for-bot
+      - toolkit/check_for_bot:
+          name: check-for-bot
       - rust-versions:
           requires:
             - check-for-bot
@@ -108,6 +109,9 @@ workflows:
           requires:
             - check-for-bot
       - toolkit/common_tests:
+          requires:
+            - check-for-bot
+      - toolkit/idiomatic_rust:
           requires:
             - check-for-bot
       - docs:
@@ -144,6 +148,7 @@ workflows:
       - toolkit/update_changelog:
           requires:
             - test-suite
+            - toolkit/idiomatic_rust
           context:
             - release
           ssh_fingerprint: << pipeline.parameters.fingerprint >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ workflows:
     jobs:
       - toolkit/check_for_bot:
           name: check-for-bot
+          context: bot-check
       - rust-versions:
           requires:
             - check-for-bot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,13 +127,16 @@ Extended validation for the secret key requires it to conform to "0x" followed b
 The input to .sitekey(sitekey) has been changed to validate that the string slice supplied is a valid UUID.
 
 The input to the .remoteip(remoteip) has been changed to validate that the string slice supplier is a valid ipv4 or ipv6 address.
+
 - Logging / Tracing*
 
 The previous version provided logging behind a feature flag. The log crate has been removed and replaced with tracing. Tracing has been instrumented for all public functions. Tracing is enabled by selected the "trace" feature.
 
 Tracing is enabled at the info logging level for public methods. Additional tracing instrumentation and messages are available at the Debug log level.
 
-The trace crates log feature is enabled so that log records are emitted if a tracing subscriber is not found.
+The trace crates log feature is enabled so that log records are
+emitted if a tracing subscriber is not found.
+
 ### Changed
 
 - Rename user_ip and site_key to conform to Hcaptcha API documentation (remoteip and sitekey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - ci-pr change entry and release building(pr [#990](https://github.com/jerus-org/hcaptcha-rs/pull/990))
-- ci-adopt the standard commands and jobs from the toolkit(pr [#996])
 
 ### Security
 
@@ -162,7 +161,6 @@ emitted if a tracing subscriber is not found.
 [#993]: https://github.com/jerus-org/hcaptcha-rs/pull/993
 [#992]: https://github.com/jerus-org/hcaptcha-rs/pull/992
 [#995]: https://github.com/jerus-org/hcaptcha-rs/pull/995
-[#996]: https://github.com/jerus-org/hcaptcha-rs/pull/996
 [Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/2.3.1...HEAD
 [2.3.1]: https://github.com/jerus-org/hcaptcha-rs/compare/2.3.0...2.3.1
 [2.3.0]: https://github.com/jerus-org/hcaptcha-rs/compare/2.2.2...2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - ci-pr change entry and release building(pr [#990](https://github.com/jerus-org/hcaptcha-rs/pull/990))
+- ci-adopt the standard commands and jobs from the toolkit(pr [#996])
 
 ### Security
 
@@ -161,6 +162,7 @@ emitted if a tracing subscriber is not found.
 [#993]: https://github.com/jerus-org/hcaptcha-rs/pull/993
 [#992]: https://github.com/jerus-org/hcaptcha-rs/pull/992
 [#995]: https://github.com/jerus-org/hcaptcha-rs/pull/995
+[#996]: https://github.com/jerus-org/hcaptcha-rs/pull/996
 [Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/2.3.1...HEAD
 [2.3.1]: https://github.com/jerus-org/hcaptcha-rs/compare/2.3.0...2.3.1
 [2.3.0]: https://github.com/jerus-org/hcaptcha-rs/compare/2.2.2...2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - ci-pr change entry and release building(pr [#990](https://github.com/jerus-org/hcaptcha-rs/pull/990))
+- ci-adopt the standard commands and jobs from the toolkit(pr [#996])
 
 ### Security
 
@@ -127,7 +128,6 @@ Extended validation for the secret key requires it to conform to "0x" followed b
 The input to .sitekey(sitekey) has been changed to validate that the string slice supplied is a valid UUID.
 
 The input to the .remoteip(remoteip) has been changed to validate that the string slice supplier is a valid ipv4 or ipv6 address.
-
 - Logging / Tracing*
 
 The previous version provided logging behind a feature flag. The log crate has been removed and replaced with tracing. Tracing has been instrumented for all public functions. Tracing is enabled by selected the "trace" feature.
@@ -136,7 +136,6 @@ Tracing is enabled at the info logging level for public methods. Additional trac
 
 The trace crates log feature is enabled so that log records are
 emitted if a tracing subscriber is not found.
-
 ### Changed
 
 - Rename user_ip and site_key to conform to Hcaptcha API documentation (remoteip and sitekey)
@@ -163,6 +162,7 @@ emitted if a tracing subscriber is not found.
 [#993]: https://github.com/jerus-org/hcaptcha-rs/pull/993
 [#992]: https://github.com/jerus-org/hcaptcha-rs/pull/992
 [#995]: https://github.com/jerus-org/hcaptcha-rs/pull/995
+[#996]: https://github.com/jerus-org/hcaptcha-rs/pull/996
 [Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/2.3.1...HEAD
 [2.3.1]: https://github.com/jerus-org/hcaptcha-rs/compare/2.3.0...2.3.1
 [2.3.0]: https://github.com/jerus-org/hcaptcha-rs/compare/2.2.2...2.3.0


### PR DESCRIPTION
* chore(circleci): add circleci toolkit orb and refactor cargo build
commands to use toolkit commands. Remove unused GPG key and git
config commands. Update workflows to use common tests toolkit command
instead of basic tests. Add toolkit command for updating changelog
and making releases.