### PR TITLE
feat(hcaptcha-cli): add async hcaptcha verification with color-eyre and tokio

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,6 +279,7 @@ workflows:
           requires:
             - common_tests
             - required_builds
+            - required builds for wasi
             - toolkit/test_doc_build
 
       - toolkit/security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - add new options for token, key, secret, and ip in CLI(pr [#1060])
+- add async hcaptcha verification with color-eyre and tokio(pr [#1061])
 
 ## [2.5.0] - 2024-09-14
 
@@ -364,6 +365,7 @@ emitted if a tracing subscriber is not found.
 [#1058]: https://github.com/jerus-org/hcaptcha-rs/pull/1058
 [#1059]: https://github.com/jerus-org/hcaptcha-rs/pull/1059
 [#1060]: https://github.com/jerus-org/hcaptcha-rs/pull/1060
+[#1061]: https://github.com/jerus-org/hcaptcha-rs/pull/1061
 [Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/v2.5.0...HEAD
 [2.5.0]: https://github.com/jerus-org/hcaptcha-rs/compare/v2.4.9...v2.5.0
 [2.4.9]: https://github.com/jerus-org/hcaptcha-rs/compare/v2.4.8...v2.4.9

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler2"
-version = "2.0.0"
+name = "adler"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
@@ -169,17 +169,17 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -307,6 +307,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +450,16 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -573,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -646,6 +683,9 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
+ "color-eyre",
+ "hcaptcha",
+ "tokio",
 ]
 
 [[package]]
@@ -848,6 +888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,11 +1035,11 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
- "adler2",
+ "adler",
 ]
 
 [[package]]
@@ -1082,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -1144,6 +1190,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "percent-encoding"
@@ -2102,6 +2154,16 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/hcaptcha-cli/Cargo.toml
+++ b/hcaptcha-cli/Cargo.toml
@@ -8,3 +8,6 @@ rust-version = "1.75"
 [dependencies]
 clap = "4.5.17"
 clap-verbosity-flag = "2.2.1"
+color-eyre = "0.6.3"
+hcaptcha = { path = "../hcaptcha", features = ["enterprise"] }
+tokio = { version = "1.40.0", features = ["rt", "macros", "rt-multi-thread"] }

--- a/hcaptcha-cli/Cargo.toml
+++ b/hcaptcha-cli/Cargo.toml
@@ -14,5 +14,8 @@ hcaptcha = { path = "../hcaptcha", features = ["enterprise"] }
 [target.x86_64-unknown-linux-gnu.dependencies]
 tokio = { version = "1.40.0", features = ["rt", "macros", "rt-multi-thread"] }
 
-[target.wasm32-unknown-unknown.dependencies]
+[target.wasm32-wasip1.dependencies]
+tokio = { version = "1.40.0", features = ["rt", "macros"] }
+
+[target.wasm32-wasi.dependencies]
 tokio = { version = "1.40.0", features = ["rt", "macros"] }

--- a/hcaptcha-cli/Cargo.toml
+++ b/hcaptcha-cli/Cargo.toml
@@ -10,4 +10,9 @@ clap = "4.5.17"
 clap-verbosity-flag = "2.2.1"
 color-eyre = "0.6.3"
 hcaptcha = { path = "../hcaptcha", features = ["enterprise"] }
+
+[target.x86_64-unknown-linux-gnu.dependencies]
 tokio = { version = "1.40.0", features = ["rt", "macros", "rt-multi-thread"] }
+
+[target.wasm32-unknown-unknown.dependencies]
+tokio = { version = "1.40.0", features = ["rt", "macros"] }

--- a/hcaptcha-cli/src/cli.rs
+++ b/hcaptcha-cli/src/cli.rs
@@ -13,7 +13,7 @@ pub struct Cli {
     pub key: Option<String>,
     /// The secret key for hcaptcha validation
     #[clap(short, long)]
-    pub secret: Option<String>,
+    pub secret: String,
     /// The ip address of the system generating the request
     #[clap(short, long)]
     pub ip: Option<String>,

--- a/hcaptcha-cli/src/main.rs
+++ b/hcaptcha-cli/src/main.rs
@@ -1,15 +1,33 @@
 use clap::Parser;
 use cli::Cli;
 use color_eyre::Result;
-use hcaptcha::{HcaptchaCaptcha, HcaptchaClient, HcaptchaRequest};
+use hcaptcha::{HcaptchaCaptcha, HcaptchaClient, HcaptchaRequest, HcaptchaResponse};
 
 mod cli;
 
+#[cfg(target_family = "wasm")]
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let args = Cli::parse();
+    println!("Args found: {:?}", args);
+
+    println!("{}", handle_cli(args).await?);
+
+    Ok(())
+}
+
+// #[cfg(target_family = "linux")]
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Cli::parse();
     println!("Args found: {:?}", args);
 
+    println!("{}", handle_cli(args).await?);
+
+    Ok(())
+}
+
+async fn handle_cli(args: Cli) -> Result<HcaptchaResponse> {
     let captcha = HcaptchaCaptcha::new(&args.token)?;
 
     let secret = args.secret;
@@ -20,6 +38,5 @@ async fn main() -> Result<()> {
 
     let res = client.verify_client_response(request).await?;
 
-    println!("{res}");
-    Ok(())
+    Ok(res)
 }

--- a/hcaptcha-cli/src/main.rs
+++ b/hcaptcha-cli/src/main.rs
@@ -1,9 +1,25 @@
 use clap::Parser;
 use cli::Cli;
+use color_eyre::Result;
+use hcaptcha::{HcaptchaCaptcha, HcaptchaClient, HcaptchaRequest};
 
 mod cli;
 
-fn main() {
+#[tokio::main]
+async fn main() -> Result<()> {
     let args = Cli::parse();
     println!("Args found: {:?}", args);
+
+    let captcha = HcaptchaCaptcha::new(&args.token)?;
+
+    let secret = args.secret;
+
+    let client = HcaptchaClient::new();
+
+    let request = HcaptchaRequest::new(&secret, captcha)?;
+
+    let res = client.verify_client_response(request).await?;
+
+    println!("{res}");
+    Ok(())
 }

--- a/hcaptcha-cli/src/main.rs
+++ b/hcaptcha-cli/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-// #[cfg(target_family = "linux")]
+#[cfg(target_family = "linux")]
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Cli::parse();

--- a/hcaptcha-cli/src/main.rs
+++ b/hcaptcha-cli/src/main.rs
@@ -5,7 +5,7 @@ use hcaptcha::{HcaptchaCaptcha, HcaptchaClient, HcaptchaRequest, HcaptchaRespons
 
 mod cli;
 
-#[cfg(target_family = "wasm")]
+#[cfg(target_os = "wasi")]
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let args = Cli::parse();
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-#[cfg(target_family = "linux")]
+#[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Cli::parse();


### PR DESCRIPTION
BREAKING CHANGE: change `secret` field in CLI to be mandatory and update dependencies in Cargo.lock and Cargo.toml