### PR TITLE
feat(hcaptcha-wasm): add new wasm example with hcaptcha integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,7 @@ Extended validation for the secret key requires it to conform to "0x" followed b
 The input to .sitekey(sitekey) has been changed to validate that the string slice supplied is a valid UUID.
 
 The input to the .remoteip(remoteip) has been changed to validate that the string slice supplier is a valid ipv4 or ipv6 address.
+
 - Logging / Tracing*
 
 The previous version provided logging behind a feature flag. The log crate has been removed and replaced with tracing. Tracing has been instrumented for all public functions. Tracing is enabled by selected the "trace" feature.
@@ -335,6 +336,7 @@ Tracing is enabled at the info logging level for public methods. Additional trac
 
 The trace crates log feature is enabled so that log records are
 emitted if a tracing subscriber is not found.
+
 ### Changed
 
 - Rename user_ip and site_key to conform to Hcaptcha API documentation (remoteip and sitekey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add simple_captcha test case to CLI test suite(pr [#1084])
 - add mock-verifier to build matrix(pr [#1105])
 - add hcaptcha integration and async test support(pr [#1109])
+- add new wasm example with hcaptcha integration(pr [#1117])
 
 ### Changed
 
@@ -327,7 +328,6 @@ Extended validation for the secret key requires it to conform to "0x" followed b
 The input to .sitekey(sitekey) has been changed to validate that the string slice supplied is a valid UUID.
 
 The input to the .remoteip(remoteip) has been changed to validate that the string slice supplier is a valid ipv4 or ipv6 address.
-
 - Logging / Tracing*
 
 The previous version provided logging behind a feature flag. The log crate has been removed and replaced with tracing. Tracing has been instrumented for all public functions. Tracing is enabled by selected the "trace" feature.
@@ -336,7 +336,6 @@ Tracing is enabled at the info logging level for public methods. Additional trac
 
 The trace crates log feature is enabled so that log records are
 emitted if a tracing subscriber is not found.
-
 ### Changed
 
 - Rename user_ip and site_key to conform to Hcaptcha API documentation (remoteip and sitekey)
@@ -480,6 +479,7 @@ emitted if a tracing subscriber is not found.
 [#1114]: https://github.com/jerus-org/hcaptcha-rs/pull/1114
 [#1116]: https://github.com/jerus-org/hcaptcha-rs/pull/1116
 [#1115]: https://github.com/jerus-org/hcaptcha-rs/pull/1115
+[#1117]: https://github.com/jerus-org/hcaptcha-rs/pull/1117
 [Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/v2.5.0...HEAD
 [2.5.0]: https://github.com/jerus-org/hcaptcha-rs/compare/v2.4.9...v2.5.0
 [2.4.9]: https://github.com/jerus-org/hcaptcha-rs/compare/v2.4.8...v2.4.9

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hcaptcha-wasm"
+version = "0.1.0"
+dependencies = [
+ "claims",
+ "hcaptcha",
+ "hcaptcha_derive",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "hcaptcha_derive"
 version = "2.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "test-suite-cli",
     "mock-verifier",
     "test-wasm",
+    "hcaptcha/examples/hcaptcha-wasm",
 ]
 
 [workspace.package]

--- a/hcaptcha/Cargo.toml
+++ b/hcaptcha/Cargo.toml
@@ -70,4 +70,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = ["js"] }
-# tokio.workspace = true

--- a/hcaptcha/examples/hcaptcha-wasm/.github/dependabot.yml
+++ b/hcaptcha/examples/hcaptcha-wasm/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "08:00"
+  open-pull-requests-limit: 10

--- a/hcaptcha/examples/hcaptcha-wasm/.gitignore
+++ b/hcaptcha/examples/hcaptcha-wasm/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log

--- a/hcaptcha/examples/hcaptcha-wasm/Cargo.toml
+++ b/hcaptcha/examples/hcaptcha-wasm/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "hcaptcha-wasm"
+version = "0.1.0"
+authors = ["Jeremiah Russell <jerry@jrussell.ie>"]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# [features]
+# default = ["console_error_panic_hook"]
+
+[dependencies]
+claims = "0.7.1"
+hcaptcha = { path = "../../", features = ["enterprise"] }
+hcaptcha_derive = { path = "../../../hcaptcha_derive" }
+wasm-bindgen = "0.2.95"
+wasm-bindgen-futures = "0.4.34"
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+# console_error_panic_hook = { version = "0.1.7", optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.34"
+
+# [profile.release]
+# # Tell `rustc` to optimize for small code size.
+# opt-level = "s"

--- a/hcaptcha/examples/hcaptcha-wasm/README.md
+++ b/hcaptcha/examples/hcaptcha-wasm/README.md
@@ -1,0 +1,26 @@
+# Example: hcaptcha-wasm
+
+Simple example project using `wasm-bindgen` to embed a [Hcaptcha](https://www.hcaptcha.com/) widget into your WebAssembly application.
+
+## Creating the project
+
+Project was created using wasm-pack:
+
+```sh
+wasm-pack new hcaptcha-wasm
+
+```
+
+Then edited to create the example.
+
+## Running the example
+
+The code compiles and runs with the current node lts version (v20.18.0).
+
+The test module runs the example using wasm-pack test:
+
+```sh
+nvm use v20.18.0
+wasm-pack test --node
+
+```

--- a/hcaptcha/examples/hcaptcha-wasm/src/lib.rs
+++ b/hcaptcha/examples/hcaptcha-wasm/src/lib.rs
@@ -1,0 +1,25 @@
+use claims::assert_ok;
+use hcaptcha::Hcaptcha;
+use wasm_bindgen::prelude::*;
+
+#[derive(Hcaptcha)]
+struct Test {
+    #[captcha]
+    hcaptcha: String,
+}
+
+#[wasm_bindgen]
+pub async fn validate_standard() {
+    let response = "10000000-aaaa-bbbb-cccc-000000000001";
+    let secret = "0x0000000000000000000000000000000000000000";
+
+    let form = Test {
+        hcaptcha: response.to_string(),
+    };
+
+    let response = form.valid_response(secret, None).await;
+
+    assert_ok!(&response);
+    let response = response.unwrap();
+    assert!(&response.success());
+}

--- a/hcaptcha/examples/hcaptcha-wasm/tests/web.rs
+++ b/hcaptcha/examples/hcaptcha-wasm/tests/web.rs
@@ -1,0 +1,10 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+async fn valid_integration_test() {
+    hcaptcha_wasm::validate_standard().await;
+}


### PR DESCRIPTION
- remove commented out tokio dependency in hcaptcha/Cargo.toml
- add dependabot configuration for automatic dependency updates
- add .gitignore for wasm example to ignore build artifacts
- create new Cargo.toml for hcaptcha-wasm example
- provide README for setting up and running the hcaptcha-wasm example
- implement hcaptcha validation logic in lib.rs for wasm example
- add integration test for hcaptcha-wasm example

issue #588