### PR TITLE
👷 ci(config): simplify package configuration in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,9 +261,7 @@ workflows:
           min_rust_version: << pipeline.parameters.min-rust-version >>
           when_cargo_release: false
           pcu_verbosity: << pipeline.parameters.pcu_verbosity >>
-          matrix:
-            parameters:
-              package: [hcaptcha, hcaptcha-derive]
+          package: hcaptcha
       - toolkit/no_release:
           min_rust_version: << pipeline.parameters.min-rust-version >>
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ workflows:
           pcu_verbosity: << pipeline.parameters.pcu_verbosity >>
           when_github_release: false
       - toolkit/make_release:
-          name: github release << matrix.package >>
+          name: github release for hcaptcha
           context:
             - release
             - bot-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- 👷 ci(config)-simplify package configuration in CircleCI(pr [#1334])
+
 ## [3.0.15] - 2025-04-23
 
 ### Changed
@@ -1168,7 +1174,9 @@ emitted if a tracing subscriber is not found.
 [#1331]: https://github.com/jerus-org/hcaptcha-rs/pull/1331
 [#1332]: https://github.com/jerus-org/hcaptcha-rs/pull/1332
 [#1333]: https://github.com/jerus-org/hcaptcha-rs/pull/1333
-[3.0.15]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.14...hcaptcha-v3.0.15
+[#1334]: https://github.com/jerus-org/hcaptcha-rs/pull/1334
+[Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.15...HEAD
+[3.0.15]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.14...v3.0.15
 [3.0.14]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.13...v3.0.14
 [3.0.13]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.12...v3.0.13
 [3.0.12]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.11...v3.0.12


### PR DESCRIPTION
- remove matrix parameters for package configuration
- set package to hcaptcha directly for streamlined setup