### PR TITLE
👷 ci(circleci): add release filters and update workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,12 @@
 version: 2.1
 
+# Filter for release tags.
+release-filters: &release-filters
+  branches:
+    ignore: /.*/
+  tags:
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+
 parameters:
   min-rust-version:
     type: string
@@ -250,13 +257,24 @@ workflows:
           min_rust_version: << pipeline.parameters.min-rust-version >>
           pcu_verbosity: << pipeline.parameters.pcu_verbosity >>
           when_github_release: false
+      - toolkit/no_release:
+          min_rust_version: << pipeline.parameters.min-rust-version >>
+          requires:
+            - toolkit/save_next_version:
+                - failed
+
+  github-release:
+    jobs:
+      - toolkit/save_next_version:
+          filters: *release-filters
+          min_rust_version: << pipeline.parameters.min-rust-version >>
       - toolkit/make_release:
           name: github release for hcaptcha
           context:
             - release
             - bot-check
           requires:
-            - cargo release
+            - toolkit/save_next_version
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
           when_cargo_release: false


### PR DESCRIPTION
- add release filters to trigger jobs on version tags only
- update workflows to include no_release job and adjust job dependencies
- ensure compatibility with defined parameters and contexts