### PR TITLE
👷 ci(circleci): update toolkit orb version and comment out flags

### DIFF
--- a/.circleci/github_release.yml
+++ b/.circleci/github_release.yml
@@ -10,29 +10,29 @@ parameters:
   fingerprint:
     type: string
     default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg
-  validation-flag:
-    type: boolean
-    default: false
-    description: "If true, the validation pipeline will be executed."
-  success-flag:
-    type: boolean
-    default: false
-    description: "If true, the success pipeline will be executed."
-  release-flag:
-    type: boolean
-    default: false
-    description: "If true, the release pipeline will be executed."
-  pcu_workspace:
-    type: boolean
-    default: true
-    description: "If true, the make release treats as workspace."
+  # validation-flag:
+  #   type: boolean
+  #   default: false
+  #   description: "If true, the validation pipeline will be executed."
+  # success-flag:
+  #   type: boolean
+  #   default: false
+  #   description: "If true, the success pipeline will be executed."
+  # release-flag:
+  #   type: boolean
+  #   default: false
+  #   description: "If true, the release pipeline will be executed."
+  # pcu_workspace:
+  #   type: boolean
+  #   default: true
+  #   description: "If true, the make release treats as workspace."
   pcu_verbosity:
     type: string
     default: "-vv"
     description: "Verbosity for pcu application executions."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@2.9.1
+  toolkit: jerus-org/circleci-toolkit@2.10.4
 
 executors:
   rust_env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- 👷 ci(circleci)-update toolkit orb version and comment out flags(pr [#1345])
+
 ## [3.0.22] - 2025-04-30
 
 ### Changed
@@ -1224,7 +1230,9 @@ emitted if a tracing subscriber is not found.
 [#1341]: https://github.com/jerus-org/hcaptcha-rs/pull/1341
 [#1342]: https://github.com/jerus-org/hcaptcha-rs/pull/1342
 [#1344]: https://github.com/jerus-org/hcaptcha-rs/pull/1344
-[3.0.22]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.21...hcaptcha-v3.0.22
+[#1345]: https://github.com/jerus-org/hcaptcha-rs/pull/1345
+[Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.22...HEAD
+[3.0.22]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.21...v3.0.22
 [3.0.21]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.20...v3.0.21
 [3.0.20]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.19...v3.0.20
 [3.0.19]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.18...v3.0.19


### PR DESCRIPTION
- update circleci-toolkit orb version from 2.9.1 to 2.10.4 for latest features
- comment out unused flag parameters for cleaner configuration