### PR TITLE
🔧 chore(ci): clean up CircleCI GitHub release config

### DIFF
--- a/.circleci/github_release.yml
+++ b/.circleci/github_release.yml
@@ -10,22 +10,6 @@ parameters:
   fingerprint:
     type: string
     default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg
-  # validation-flag:
-  #   type: boolean
-  #   default: false
-  #   description: "If true, the validation pipeline will be executed."
-  # success-flag:
-  #   type: boolean
-  #   default: false
-  #   description: "If true, the success pipeline will be executed."
-  # release-flag:
-  #   type: boolean
-  #   default: false
-  #   description: "If true, the release pipeline will be executed."
-  # pcu_workspace:
-  #   type: boolean
-  #   default: true
-  #   description: "If true, the make release treats as workspace."
   pcu_verbosity:
     type: string
     default: "-vv"
@@ -45,24 +29,14 @@ executors:
 workflows:
   github-release:
     jobs:
-      - toolkit/save_next_version:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
       - toolkit/make_release:
           name: github release for hcaptcha
           context:
             - release
             - bot-check
-          requires:
-            - toolkit/save_next_version
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
           when_cargo_release: false
           pcu_verbosity: << pipeline.parameters.pcu_verbosity >>
           package: hcaptcha
-          when_update_pcu: true
           remove_ssh_key: false
-      - toolkit/no_release:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
-          requires:
-            - toolkit/save_next_version:
-                - failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - 👷 ci(circleci)-update toolkit orb version and comment out flags(pr [#1345])
+- 🔧 chore(ci)-clean up CircleCI GitHub release config(pr [#1346])
 
 ## [3.0.22] - 2025-04-30
 
@@ -1231,6 +1232,7 @@ emitted if a tracing subscriber is not found.
 [#1342]: https://github.com/jerus-org/hcaptcha-rs/pull/1342
 [#1344]: https://github.com/jerus-org/hcaptcha-rs/pull/1344
 [#1345]: https://github.com/jerus-org/hcaptcha-rs/pull/1345
+[#1346]: https://github.com/jerus-org/hcaptcha-rs/pull/1346
 [Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.22...HEAD
 [3.0.22]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.21...v3.0.22
 [3.0.21]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.20...v3.0.21


### PR DESCRIPTION
- remove commented-out validation, success, release, and workspace flags
- delete unused job dependencies and redundant steps for streamlining