### PR TITLE
👷 ci(circleci): update circleci toolkit orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  toolkit: jerus-org/circleci-toolkit@2.10.7
-
 # Filter for release tags.
 release-filters: &release-filters
   branches:
@@ -40,6 +37,9 @@ parameters:
     type: string
     default: "-vv"
     description: "Verbosity for pcu application executions."
+
+orbs:
+  toolkit: jerus-org/circleci-toolkit@2.10.7
 
 executors:
   rust_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  toolkit: jerus-org/circleci-toolkit@2.10.5
+
 # Filter for release tags.
 release-filters: &release-filters
   branches:
@@ -37,9 +40,6 @@ parameters:
     type: string
     default: "-vv"
     description: "Verbosity for pcu application executions."
-
-orbs:
-  toolkit: jerus-org/circleci-toolkit@2.10.4
 
 executors:
   rust_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,10 @@ workflows:
                 - failed
 
   github-release:
+    when:
+      not:
+        equal: ["", << pipeline.git.tag >>]
+
     jobs:
       - toolkit/save_next_version:
           filters: *release-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@2.10.5
+  toolkit: jerus-org/circleci-toolkit@2.10.6
 
 # Filter for release tags.
 release-filters: &release-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@2.10.6
+  toolkit: jerus-org/circleci-toolkit@2.10.7
 
 # Filter for release tags.
 release-filters: &release-filters

--- a/.circleci/github_release.yml
+++ b/.circleci/github_release.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  toolkit: jerus-org/circleci-toolkit@2.10.5
+
 parameters:
   min-rust-version:
     type: string
@@ -14,9 +17,6 @@ parameters:
     type: string
     default: "-vv"
     description: "Verbosity for pcu application executions."
-
-orbs:
-  toolkit: jerus-org/circleci-toolkit@2.10.4
 
 executors:
   rust_env:

--- a/.circleci/github_release.yml
+++ b/.circleci/github_release.yml
@@ -38,5 +38,6 @@ workflows:
           min_rust_version: << pipeline.parameters.min-rust-version >>
           when_cargo_release: false
           pcu_verbosity: << pipeline.parameters.pcu_verbosity >>
+          when_update_pcu: true
           package: hcaptcha
           remove_ssh_key: false

--- a/.circleci/github_release.yml
+++ b/.circleci/github_release.yml
@@ -41,4 +41,3 @@ workflows:
           package: hcaptcha
           remove_ssh_key: false
           when_update_pcu: true
-          # when_get_version: false

--- a/.circleci/github_release.yml
+++ b/.circleci/github_release.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@2.10.6
+  toolkit: jerus-org/circleci-toolkit@2.10.7
 
 parameters:
   min-rust-version:

--- a/.circleci/github_release.yml
+++ b/.circleci/github_release.yml
@@ -38,6 +38,7 @@ workflows:
           min_rust_version: << pipeline.parameters.min-rust-version >>
           when_cargo_release: false
           pcu_verbosity: << pipeline.parameters.pcu_verbosity >>
-          when_update_pcu: true
           package: hcaptcha
           remove_ssh_key: false
+          when_update_pcu: true
+          when_get_version: false

--- a/.circleci/github_release.yml
+++ b/.circleci/github_release.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@2.10.5
+  toolkit: jerus-org/circleci-toolkit@2.10.6
 
 parameters:
   min-rust-version:

--- a/.circleci/github_release.yml
+++ b/.circleci/github_release.yml
@@ -41,4 +41,4 @@ workflows:
           package: hcaptcha
           remove_ssh_key: false
           when_update_pcu: true
-          when_get_version: false
+          # when_get_version: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- 👷 ci(circleci)-update circleci toolkit orb version(pr [#1348])
+
 ## [3.0.23] - 2025-04-30
 
 ### Changed
@@ -1235,7 +1241,9 @@ emitted if a tracing subscriber is not found.
 [#1345]: https://github.com/jerus-org/hcaptcha-rs/pull/1345
 [#1346]: https://github.com/jerus-org/hcaptcha-rs/pull/1346
 [#1347]: https://github.com/jerus-org/hcaptcha-rs/pull/1347
-[3.0.23]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.22...hcaptcha-v3.0.23
+[#1348]: https://github.com/jerus-org/hcaptcha-rs/pull/1348
+[Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.23...HEAD
+[3.0.23]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.22...v3.0.23
 [3.0.22]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.21...v3.0.22
 [3.0.21]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.20...v3.0.21
 [3.0.20]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.19...v3.0.20


### PR DESCRIPTION
- upgrade toolkit orb from 2.10.4 to 2.10.5 in config.yml and github_release.yml
- ensure compatibility with the latest ci features and improvements