### PR TITLE
👷 ci(circleci): remove unused configuration parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,5 +275,3 @@ workflows:
           when_cargo_release: false
           pcu_verbosity: << pipeline.parameters.pcu_verbosity >>
           package: hcaptcha
-          remove_ssh_key: false
-          when_update_pcu: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- 👷 ci(circleci)-remove unused configuration parameters(pr [#1353])
+
 ## [3.0.25] - 2025-05-01
 
 ### Changed
@@ -1249,7 +1255,9 @@ emitted if a tracing subscriber is not found.
 [#1347]: https://github.com/jerus-org/hcaptcha-rs/pull/1347
 [#1348]: https://github.com/jerus-org/hcaptcha-rs/pull/1348
 [#1349]: https://github.com/jerus-org/hcaptcha-rs/pull/1349
-[3.0.25]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.24...hcaptcha-v3.0.25
+[#1353]: https://github.com/jerus-org/hcaptcha-rs/pull/1353
+[Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.25...HEAD
+[3.0.25]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.24...v3.0.25
 [3.0.24]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.23...v3.0.24
 [3.0.23]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.22...v3.0.23
 [3.0.22]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.21...v3.0.22


### PR DESCRIPTION
- delete `remove_ssh_key` and `when_update_pcu` parameters to clean up CircleCI config
- improve clarity and maintainability by removing unnecessary entries