### PR TITLE
Use-new-formatting-syntax-for-variables

### DIFF
--- a/test-suite-cli/src/bin/short_help.rs
+++ b/test-suite-cli/src/bin/short_help.rs
@@ -22,11 +22,11 @@ fn main() {
     let cmd = cargo_bin("hcaptcha-cli");
 
     let mut cmd = Cmd::new(&cmd);
-    println!("cmd: {:?}", cmd);
+    println!("cmd: {cmd:?}");
 
     let output_res = cmd.arg("-h").output();
 
-    println!("output result: {:#?}", output_res);
+    println!("output result: {output_res:#?}");
 
     let output = output_res.expect("failed to spawn");
 

--- a/test-suite-cli/src/bin/simple_captcha.rs
+++ b/test-suite-cli/src/bin/simple_captcha.rs
@@ -22,11 +22,11 @@ fn main() {
     let cmd = cargo_bin("hcaptcha-cli");
 
     let mut cmd = Cmd::new(&cmd);
-    println!("cmd: {:?}", cmd);
+    println!("cmd: {cmd:?}");
 
     let output_res = cmd.arg("-h").output();
 
-    println!("output result: {:#?}", output_res);
+    println!("output result: {output_res:#?}");
 
     let output = output_res.expect("failed to spawn");
 

--- a/test-suite-cli/src/lib.rs
+++ b/test-suite-cli/src/lib.rs
@@ -37,7 +37,7 @@ impl Cmd {
 
 pub fn cargo_bin(name: &str) -> std::path::PathBuf {
     let bin = if env::var("WASI").is_ok() {
-        let file_name = format!("{}{}", name, WASM_SUFFIX);
+        let file_name = format!("{name}{WASM_SUFFIX}");
         let bin_dir = bin_dir();
         bin_dir.join(file_name)
     } else {


### PR DESCRIPTION
- update println! macro to use new formatting syntax for better readability
- apply changes across multiple source files in the test-suite-cli