### PR TITLE
Simplify-renovate-configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,8 +199,8 @@ jobs:
                 committer: "<< parameters.committer >>"
                 pipeline_flag_if_not: "<< parameters.pipeline_flag_test_failed >>"
                 pipeline_flag_if: "<< parameters.pipeline_flag_test_passed >>"
-                pipeline_pcu_verbosity: "<< pipeline.parameters.pcu_verbosity >>"
-                pipeline_pcu_allow_no_pull_request: "<< pipeline.parameters.pcu_allow_no_pull_request >>"
+                pipeline_pcu_verbosity: "<< pipeline.parameters.pipeline_pcu_verbosity >>"
+                pipeline_pcu_allow_no_pull_request: "<< pipeline.parameters.pipeline_pcu_allow_no_pull_request >>"
 
 workflows:
   check_last_commit:
@@ -217,7 +217,7 @@ workflows:
           name: choose pipeline based on committer
           context: bot-check
           pipeline_pcu_verbosity: << pipeline.parameters.pcu_verbosity >>
-          pipeline_pcu_allow_no_pull_request: << pipeline.parameters.pcu_allow_no_pull_request >>
+          pipeline_pcu_allow_no_pull_request: << pipeline.parameters.pipeline_pcu_allow_no_pull_request >>
 
   validation:
     when:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "dd'T'HH",
         "fakeit",
         "hcaptcha",
+        "hcapthca",
         "invalidhcaptchastring",
         "itertools",
         "Itertools",
@@ -16,8 +17,10 @@
         "sitekeys",
         "siteverify",
         "Struct",
+        "testdata",
         "thisisnotapropertoken",
-        "thisisthelonglistofcharactersthatformsaresponse"
+        "thisisthelonglistofcharactersthatformsaresponse",
+        "Unkown"
     ],
     "conventionalCommits.scopes": [
         "lambda-contact",

--- a/hcaptcha/src/error.rs
+++ b/hcaptcha/src/error.rs
@@ -156,7 +156,7 @@ impl fmt::Display for Code {
             Code::SecretVersionUnknown => {
                 write!(f, "The version of the site secret is not recognise.")
             }
-            Code::Unknown(e) => write!(f, "Unkown error: {e}"),
+            Code::Unknown(e) => write!(f, "Unknown error: {e}"),
         }
     }
 }
@@ -299,7 +299,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fmt_invlid_secret_ext_wrong_len() {
+    fn test_fmt_invalid_secret_ext_wrong_len() {
         let code = Code::InvalidSecretExtWrongLen;
         let formatted = format!("{code}");
         assert_eq!(formatted, "Secret key is not the correct length.");

--- a/renovate.json
+++ b/renovate.json
@@ -1,81 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "rangeStrategy": "bump",
-  "semanticCommits": "enabled",
-  "semanticCommitType": "fix",
   "schedule": [
     "* 0-5 24 * *"
   ],
-  "prConcurrentLimit": 0,
-  "prHourlyLimit": 0,
-  "versioning": "cargo",
-  "packageRules": [
-    {
-      "matchPackageNames": [
-        "!jerusdp/ci-rust"
-      ]
-    },
-    {
-      "groupName": "futures packages",
-      "matchPackageNames": [
-        "/^futures[-_]?/"
-      ]
-    },
-    {
-      "groupName": "serde packages",
-      "matchPackageNames": [
-        "/^serde[-_]?/"
-      ]
-    },
-    {
-      "groupName": "tokio packages",
-      "matchPackageNames": [
-        "/^tokio[-_]?/"
-      ]
-    },
-    {
-      "groupName": "tracing packages",
-      "matchPackageNames": [
-        "/^tracing[-_]?/",
-        "!tracing-opentelemetry"
-      ]
-    },
-    {
-      "groupName": "liquid packages",
-      "matchPackageNames": [
-        "/^liquid[-_]?/",
-        "/^kstring$/"
-      ]
-    },
-    {
-      "automerge": true,
-      "matchPackageNames": [
-        "/github/codeql-action/",
-        "/ossf/scorecard-action/",
-        "/actions/checkout/"
-      ]
-    },
-    {
-      "sourceUrl": "https://github.com/jerus-org/circleci-toolkit",
-      "enabled": true,
-      "matchPackageNames": [
-        "/jerus-org/circleci-toolkit/"
-      ]
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "^rust-toolchain\\.toml?$"
-      ],
-      "matchStrings": [
-        "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
-      ],
-      "depNameTemplate": "rust",
-      "packageNameTemplate": "rust-lang/rust",
-      "datasourceTemplate": "github-releases"
-    }
+  "extends": [
+    "github>jerusdp/renovate-config:default.json"
   ]
 }

--- a/test-suite-cli/src/bin/short_help.rs
+++ b/test-suite-cli/src/bin/short_help.rs
@@ -7,7 +7,7 @@ fn main() {
     // Options:
     //   -v, --verbose...       Increase logging verbosity
     //   -q, --quiet...         Decrease logging verbosity
-    //   -t, --token <TOKEN>    The captcha token proivded by the client for validation
+    //   -t, --token <TOKEN>    The captcha token provided by the client for validation
     //   -k, --key <KEY>        The sitekey for hcapthca validation
     //   -s, --secret <SECRET>  The secret key for hcaptcha validation
     //   -i, --ip <IP>          The ip address of the system generating the request

--- a/test-suite-cli/src/bin/simple_captcha.rs
+++ b/test-suite-cli/src/bin/simple_captcha.rs
@@ -7,7 +7,7 @@ fn main() {
     // Options:
     //   -v, --verbose...       Increase logging verbosity
     //   -q, --quiet...         Decrease logging verbosity
-    //   -t, --token <TOKEN>    The captcha token proivded by the client for validation
+    //   -t, --token <TOKEN>    The captcha token provided by the client for validation
     //   -k, --key <KEY>        The sitekey for hcapthca validation
     //   -s, --secret <SECRET>  The secret key for hcaptcha validation
     //   -i, --ip <IP>          The ip address of the system generating the request


### PR DESCRIPTION
- fix incorrect parameter names for pipeline_pcu_verbosity and pipeline_pcu_allow_no_pull_request

🐛 fix(vscode): add missing words in spelling configuration
  - add "hcapthca", "testdata", and "Unkown" to word list

🐛 fix(error): correct spelling mistakes in error messages
  - change "Unkown" to "Unknown" and "invlid" to "invalid"

🐛 fix(cli): correct spelling mistake in CLI help messages
  - change "proivded" to "provided" in token option description