### PR TITLE
🔧 chore(release-hook): update release script for hcaptcha

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔧 chore(release)-update pre-release replacements in release.toml(pr [#1416])
 - 👷 ci(circleci)-update circleci toolkit version(pr [#1417])
 - ♻️ refactor(release-hook)-remove redundant README build steps(pr [#1418])
+- 🔧 chore(release-hook)-update release script for hcaptcha(pr [#1419])
 
 ## [3.0.31] - 2025-09-28
 
@@ -1440,6 +1441,7 @@ emitted if a tracing subscriber is not found.
 [#1416]: https://github.com/jerus-org/hcaptcha-rs/pull/1416
 [#1417]: https://github.com/jerus-org/hcaptcha-rs/pull/1417
 [#1418]: https://github.com/jerus-org/hcaptcha-rs/pull/1418
+[#1419]: https://github.com/jerus-org/hcaptcha-rs/pull/1419
 [Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.31...HEAD
 [3.0.31]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.30...v3.0.31
 [3.0.30]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.29...v3.0.30

--- a/hcaptcha/release-hook.sh
+++ b/hcaptcha/release-hook.sh
@@ -1,4 +1,14 @@
-#!/bin/sh
+#!/bin/bash
+set -exo pipefail
+
+NAME="CHANGE.md"
+PACKAGE=hcaptcha_derive
+REPO_DIR="../."
 
 # Build Changelog
-gen-changelog generate --display-summaries --name CHANGE.md --package hcaptcha --next-version "$SEMVER"
+gen-changelog generate \
+    --display-summaries \
+    --name ${NAME} \
+    --package ${PACKAGE} \
+    --repository-dir ${REPO_DIR} \
+    --next-version "$SEMVER"

--- a/hcaptcha/release.toml
+++ b/hcaptcha/release.toml
@@ -6,8 +6,8 @@ allow-branch = ["main"]
 pre-release-replacements = [
     { file = "README.md", search = "hcaptcha = .*", replace = "{{crate_name}} = \"{{version}}\"" },
     { file = "src/lib.rs", search = "version = .+,", replace = "version = \"{{version}}\",", exactly = 1 },
-    { file = "PRLOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
-    { file = "PRLOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
-    { file = "PRLOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
+    { file = "../PRLOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
+    { file = "../PRLOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
+    { file = "../PRLOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
 ]
 pre-release-hook = ["./release-hook.sh"]

--- a/hcaptcha_derive/release-hook.sh
+++ b/hcaptcha_derive/release-hook.sh
@@ -1,4 +1,14 @@
-#!/bin/sh
+#!/bin/bash
+set -exo pipefail
+
+NAME="CHANGE.md"
+PACKAGE=hcaptcha_derive
+REPO_DIR="../."
 
 # Build Changelog
-gen-changelog generate --display-summaries --name CHANGE.md --package hcaptcha_derive --next-version "$SEMVER"
+gen-changelog generate \
+    --display-summaries \
+    --name ${NAME} \
+    --package ${PACKAGE} \
+    --repository-dir ${REPO_DIR} \
+    --next-version "$SEMVER"


### PR DESCRIPTION
- adjust file path for PRLOG.md in pre-release replacements to ensure correct file location is targeted during release process