### PR TITLE
ci(circleci): remove SonarCloud context from audit workflow

### DIFF
--- a/.circleci/audit.yml
+++ b/.circleci/audit.yml
@@ -7,4 +7,4 @@ workflows:
   audit:
     jobs:
       - toolkit/security:
-          context: SonarCloud
+          sonarcloud: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ parameters:
 
 orbs:
   toolkit: jerus-org/circleci-toolkit@2.16.0
+  sonarcloud: sonarsource/sonarcloud@3.0.1
 
 executors:
   rust_env:
@@ -96,6 +97,54 @@ jobs:
           cargo_package: << parameters.cargo_package >>
           cargo_bin: << parameters.cargo_bin >>
 
+  security:
+    description: >
+      Perform security checks on the code
+
+    executor:
+      name: base-env
+
+    parameters:
+      ignore_advisories:
+        default: ""
+        description: List of advisories to ignore each prefixed with "--ignore "
+        type: string
+      cargo_audit:
+        default: true
+        description: Run the cargo audit scan
+        type: boolean
+      sonarcloud:
+        default: true
+        description: Run the sonarcloud scan
+        type: boolean
+      main_audit_only:
+        default: false
+        description: Don't run sonarcloud if branch is main
+        type: boolean
+
+    steps:
+      - checkout
+      - when:
+          condition: << parameters.cargo_audit >>
+          steps:
+            - toolkit/cargo_audit:
+                ignore_advisories: << parameters.ignore_advisories >>
+      - when:
+          condition:
+            or:
+              # Case 1: main branch, both conditions must hold
+              - and:
+                  - equal: [main, << pipeline.git.branch >>]
+                  - equal: [true, << parameters.sonarcloud >>]
+                  - equal: [false, << parameters.main_audit_only >>]
+              # Case 2: non-main branch, only param_positive matters
+              - and:
+                  - not:
+                      equal: [main, << pipeline.git.branch >>]
+                  - equal: [true, << parameters.sonarcloud >>]
+          steps:
+            - sonarcloud/scan
+
 workflows:
   check_last_commit:
     when:
@@ -131,7 +180,7 @@ workflows:
           min_rust_version: << pipeline.parameters.min-rust-version >>
           package: hcaptcha
           requires:
-            - toolkit/security
+            - security
       - toolkit/required_builds:
           name: required builds-<< matrix.cargo_package >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
@@ -141,7 +190,7 @@ workflows:
               cargo_package:
                 [hcaptcha, hcaptcha_derive, hcaptcha-cli, mock-verifier]
           requires:
-            - toolkit/security
+            - security
       - toolkit/optional_builds:
           name: optional builds-<< matrix.cargo_package >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
@@ -149,19 +198,19 @@ workflows:
           matrix:
             <<: *builds
           requires:
-            - toolkit/security
+            - security
       - toolkit/common_tests:
           name: common tests for x86_64-<< matrix.cargo_package >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
           matrix:
             <<: *builds
           requires:
-            - toolkit/security
+            - security
       - toolkit/idiomatic_rust:
           min_rust_version: << pipeline.parameters.min-rust-version >>
           lint_flags: "-A deprecated"
           requires:
-            - toolkit/security
+            - security
       - toolkit/test_doc_build:
           min_rust_version: << pipeline.parameters.min-rust-version >>
       - run_test_program:
@@ -200,8 +249,9 @@ workflows:
             - toolkit/required_builds
             - toolkit/test_doc_build
 
-      - toolkit/security:
+      - security:
           context: SonarCloud
+          main_audit_only: true
 
       - toolkit/update_prlog:
           requires:

--- a/PRLOG.md
+++ b/PRLOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - 📦 build(ci)-add circleci audit config(pr [#1441])
+- ci(circleci)-remove SonarCloud context from audit workflow(pr [#1447])
 
 ### Fixed
 
@@ -1514,6 +1515,7 @@ emitted if a tracing subscriber is not found.
 [#1443]: https://github.com/jerus-org/hcaptcha-rs/pull/1443
 [#1445]: https://github.com/jerus-org/hcaptcha-rs/pull/1445
 [#1446]: https://github.com/jerus-org/hcaptcha-rs/pull/1446
+[#1447]: https://github.com/jerus-org/hcaptcha-rs/pull/1447
 [Unreleased]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.1.0...HEAD
 [3.1.0]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.33...v3.1.0
 [3.0.33]: https://github.com/jerus-org/hcaptcha-rs/compare/v3.0.32...v3.0.33


### PR DESCRIPTION
- remove SonarCloud context requirement from security job in audit workflow
- add branch filtering to security job in main config to exclude main branch
- consolidate security job configuration to avoid context duplication
- prevent redundant security scans on main branch where they're unnecessary
- maintain security coverage for feature branches while reducing CI overhead