### PR TITLE
fix(ci): bump wasm canary toolkit to 6.1.2 for create_issue

### DIFF
--- a/.circleci/wasm_nightly_canary.yml
+++ b/.circleci/wasm_nightly_canary.yml
@@ -52,7 +52,7 @@ version: 2.1
 # ─────────────────────────────────────────────────────────────────────────────
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.0.0
+  toolkit: jerus-org/circleci-toolkit@6.1.2
   node: circleci/node@6.3.0
 
 jobs:


### PR DESCRIPTION
## Summary

- Bumps `jerus-org/circleci-toolkit` from `6.0.0` to `6.1.2` in `wasm_nightly_canary.yml`
- `toolkit/create_issue` was added in toolkit 6.1.0 (PR #443); the canary pipeline would fail with `Cannot find a definition for command named toolkit/create_issue` on `6.0.0`

## Test plan

- [ ] Pipeline runs without the `Cannot find a definition for command` error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)