### PR TITLE
fix(ci): install nightly in user-writable RUSTUP_HOME

### DIFF
--- a/.circleci/wasm_nightly_canary.yml
+++ b/.circleci/wasm_nightly_canary.yml
@@ -65,11 +65,18 @@ jobs:
       - node/install
 
       - run:
-          name: Update to latest nightly and add wasm32-unknown-unknown target
+          name: Install latest nightly with wasm32-unknown-unknown target
           command: |
-            rustup update nightly
-            rustup target add wasm32-unknown-unknown --toolchain nightly
-            echo "Nightly version: $(cargo +nightly --version)"
+            # /usr/local/rustup is root-owned in the rolling image; the circleci
+            # user cannot update it. Install the latest nightly into a
+            # user-writable location instead so we always test the true latest.
+            echo 'export RUSTUP_HOME=/home/circleci/.rustup-user' >> "$BASH_ENV"
+            source "$BASH_ENV"
+            rustup toolchain install nightly \
+              --target wasm32-unknown-unknown \
+              --profile minimal \
+              --no-self-update
+            echo "Nightly version: $(rustup run nightly cargo --version)"
 
       - run:
           name: Run WASM tests on nightly (undefined-symbol canary)


### PR DESCRIPTION
## Summary

- Fixes pipeline failure: `rustup update nightly` errors with `Permission denied` because `/usr/local/rustup` is root-owned in the rolling image
- Replaces the update+target-add approach with a fresh install into `/home/circleci/.rustup-user` (user-writable)
- Sets `RUSTUP_HOME` in `$BASH_ENV` so subsequent steps (`wasm-pack test`) resolve the nightly toolchain from the same location
- `--profile minimal` keeps the download to just `rustc`, `cargo`, and `rust-std` for `wasm32-unknown-unknown`

## Root cause

The `rust_wasi_rolling` image installs toolchains as root into `/usr/local/rustup`. The `circleci` user has read access but not write access, so `rustup update` and `rustup target add` both fail with `os error 13`.

## Test plan

- [ ] Pipeline runs without permission errors on `rustup`
- [ ] `wasm-pack test --node` succeeds using the user-space nightly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)