### PR TITLE
fix: drop proc-macro-error2 from hcaptcha_derive

### DIFF
--- a/.circleci/audit.yml
+++ b/.circleci/audit.yml
@@ -5,7 +5,7 @@
 version: 2.1
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 workflows:
   audit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ parameters:
     default: "1.88"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 # Reusable command to set reproducible-build environment variables.
 commands:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -19,7 +19,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 jobs:
   tools:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -12,7 +12,7 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 workflows:
   update_prlog:

--- a/.circleci/wasm_nightly_canary.yml
+++ b/.circleci/wasm_nightly_canary.yml
@@ -52,7 +52,7 @@ version: 2.1
 # ─────────────────────────────────────────────────────────────────────────────
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
   node: circleci/node@7.2.1
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,6 @@ version = "3.2.3"
 dependencies = [
  "hcaptcha",
  "macrotest",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1947,28 +1946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ log = "0.4.29"
 macrotest = "1.2.1"
 mockd = { version = "0.5.3", features = ["internet", "unique", "words"] }
 proc-macro2 = "1.0.106"
-proc-macro-error2 = "2.0.1"
 quote = "1.0.45"
 rand = "0.10.1"
 reqwest = { version = "0.13.4", default-features = false, features = [

--- a/crates/hcaptcha_derive/Cargo.toml
+++ b/crates/hcaptcha_derive/Cargo.toml
@@ -33,7 +33,6 @@ proc-macro = true
 syn.workspace = true
 quote.workspace = true
 proc-macro2.workspace = true
-proc-macro-error2.workspace = true
 
 [dev-dependencies]
 hcaptcha = { path = "../hcaptcha" }

--- a/crates/hcaptcha_derive/src/lib.rs
+++ b/crates/hcaptcha_derive/src/lib.rs
@@ -104,7 +104,6 @@ use std::collections::HashMap;
 
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
-use proc_macro_error2::proc_macro_error;
 use quote::quote;
 use syn::{Data, DataStruct, DeriveInput};
 
@@ -125,28 +124,27 @@ use syn::{Data, DataStruct, DeriveInput};
 ///     token: String,
 /// }
 /// ```
-#[proc_macro_error]
 #[proc_macro_derive(Hcaptcha, attributes(captcha, remoteip, sitekey))]
 pub fn hcaptcha_derive(input: TokenStream) -> TokenStream {
     // Construct a representation of Rust code as a syntax tree
     // that we can manipulate
     let ast = syn::parse(input).unwrap();
 
-    // Build the trait implementation
-    impl_hcaptcha(&ast)
+    // Build the trait implementation, emitting any error as a compile_error!.
+    impl_hcaptcha(&ast).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
-fn impl_hcaptcha(ast: &DeriveInput) -> TokenStream {
+fn impl_hcaptcha(ast: &DeriveInput) -> Result<TokenStream, syn::Error> {
     let name = &ast.ident;
     let generics = &ast.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let data = &ast.data;
 
-    let data_struct = get_struct_data(data, name);
+    let data_struct = get_struct_data(data, name)?;
 
     let attributes = get_attributes(data_struct);
 
-    let captcha = get_required_attribute(&attributes, "captcha", name);
+    let captcha = get_required_attribute(&attributes, "captcha", name)?;
 
     let remoteip = get_optional_attribute(&attributes, "remoteip", "set_remoteip");
     let sitekey = get_optional_attribute(&attributes, "sitekey", "set_sitekey");
@@ -179,7 +177,7 @@ fn impl_hcaptcha(ast: &DeriveInput) -> TokenStream {
             }
         }
     };
-    gen.into()
+    Ok(gen.into())
 }
 
 /// Generate tokens for optional attribute
@@ -231,11 +229,11 @@ fn get_required_attribute(
     attributes: &HashMap<String, &proc_macro2::Ident>,
     name: &str,
     id: &proc_macro2::Ident,
-) -> proc_macro2::TokenStream {
+) -> Result<proc_macro2::TokenStream, syn::Error> {
     match attributes.get(name) {
         Some(i) => {
             let i = <&proc_macro2::Ident>::clone(i);
-            quote! {
+            Ok(quote! {
                 #[allow(unused_mut)]
                 let mut captcha;
                 match hcaptcha::Captcha::new(&self.#i) {
@@ -244,7 +242,7 @@ fn get_required_attribute(
                         return Box::pin(async{Err(e)});
                     }
                 };
-            }
+            })
         }
         None => {
             let example = r#"
@@ -253,11 +251,14 @@ fn get_required_attribute(
             #[captcha]
             hcaptcha: String,
         }"#;
-            proc_macro_error2::abort! {id,
-                "Field containing hcaptcha not identified";
-                help = "The field containing the hcaptcha response string must be identified with #[captcha]
-                {}", &example;
-            };
+            Err(syn::Error::new_spanned(
+                id,
+                format!(
+                    "Field containing hcaptcha not identified\n\n\
+                     help: The field containing the hcaptcha response string must be identified with #[captcha]\n\
+                     {example}"
+                ),
+            ))
         }
     }
 }
@@ -265,9 +266,9 @@ fn get_required_attribute(
 /// Extract the tokens for the Struct from the data
 /// If the data is not stored in the Struct variant abort compilation
 /// with an error.
-fn get_struct_data<'a>(data: &'a Data, name: &Ident) -> &'a DataStruct {
+fn get_struct_data<'a>(data: &'a Data, name: &Ident) -> Result<&'a DataStruct, syn::Error> {
     match data {
-        Data::Struct(s) => s,
+        Data::Struct(s) => Ok(s),
         _ => {
             let example = r#"
         #[derive(Hcaptcha)]
@@ -275,11 +276,14 @@ fn get_struct_data<'a>(data: &'a Data, name: &Ident) -> &'a DataStruct {
             #[captcha]
             hcaptcha: String,
         }"#;
-            proc_macro_error2::abort! {name,
-                "Must derive on a struct";
-                help = "This macro can only be implemented on a struct.
-                {}", &example;
-            };
+            Err(syn::Error::new_spanned(
+                name,
+                format!(
+                    "Must derive on a struct\n\n\
+                     help: This macro can only be implemented on a struct.\n\
+                     {example}"
+                ),
+            ))
         }
     }
 }
@@ -373,7 +377,7 @@ mod tests {
         attributes.insert("captcha".to_string(), &field_ident);
 
         let result = get_required_attribute(&attributes, "captcha", &struct_ident);
-        assert!(!result.is_empty());
+        assert!(!result.unwrap().is_empty());
     }
 
     #[test]
@@ -384,10 +388,13 @@ mod tests {
 
         attributes.insert("wrong_name".to_string(), &field_ident);
 
-        std::panic::catch_unwind(|| {
-            get_required_attribute(&attributes, "captcha", &struct_ident);
-        })
-        .expect_err("Should panic when captcha field is not found");
+        // Missing #[captcha] field now yields a recoverable syn::Error
+        // (emitted as a compile_error!) instead of aborting/panicking.
+        let result = get_required_attribute(&attributes, "captcha", &struct_ident);
+        let err = result.expect_err("should error when captcha field is not found");
+        assert!(err
+            .to_string()
+            .contains("Field containing hcaptcha not identified"));
     }
 
     #[test]
@@ -401,7 +408,7 @@ mod tests {
         attributes.insert("other".to_string(), &other_field);
 
         let result = get_required_attribute(&attributes, "captcha", &struct_ident);
-        assert!(!result.is_empty());
+        assert!(!result.unwrap().is_empty());
     }
 
     #[test]
@@ -419,7 +426,7 @@ mod tests {
         let data = Data::Struct(data_struct.clone());
 
         let result = get_struct_data(&data, &name);
-        assert_eq!(result, &data_struct);
+        assert_eq!(result.unwrap(), &data_struct);
     }
 
     #[test]

--- a/crates/hcaptcha_derive/tests/compile_fail/complete_enum.stderr
+++ b/crates/hcaptcha_derive/tests/compile_fail/complete_enum.stderr
@@ -1,13 +1,12 @@
 error: Must derive on a struct
 
-         = help: This macro can only be implemented on a struct.
+       help: This macro can only be implemented on a struct.
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/compile_fail/complete_enum.rs:8:10
   |
 8 | pub enum ContactEnum {

--- a/crates/hcaptcha_derive/tests/compile_fail/no_field_enum.stderr
+++ b/crates/hcaptcha_derive/tests/compile_fail/no_field_enum.stderr
@@ -1,13 +1,12 @@
 error: Must derive on a struct
 
-         = help: This macro can only be implemented on a struct.
+       help: This macro can only be implemented on a struct.
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/compile_fail/no_field_enum.rs:8:10
   |
 8 | pub enum ContactEnum {

--- a/crates/hcaptcha_derive/tests/compile_fail/no_field_struct.stderr
+++ b/crates/hcaptcha_derive/tests/compile_fail/no_field_struct.stderr
@@ -1,13 +1,12 @@
 error: Field containing hcaptcha not identified
 
-         = help: The field containing the hcaptcha response string must be identified with #[captcha]
+       help: The field containing the hcaptcha response string must be identified with #[captcha]
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/compile_fail/no_field_struct.rs:8:12
   |
 8 | pub struct ContactForm {

--- a/crates/test-suite-default/tests/ui/compilefail/captcha_not_identified.stderr
+++ b/crates/test-suite-default/tests/ui/compilefail/captcha_not_identified.stderr
@@ -1,13 +1,12 @@
 error: Field containing hcaptcha not identified
 
-         = help: The field containing the hcaptcha response string must be identified with #[captcha]
+       help: The field containing the hcaptcha response string must be identified with #[captcha]
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/captcha_not_identified.rs:8:8
   |
 8 | struct Test {

--- a/crates/test-suite-default/tests/ui/compilefail/not_a_struct.stderr
+++ b/crates/test-suite-default/tests/ui/compilefail/not_a_struct.stderr
@@ -1,13 +1,12 @@
 error: Must derive on a struct
 
-         = help: This macro can only be implemented on a struct.
+       help: This macro can only be implemented on a struct.
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/not_a_struct.rs:9:6
   |
 9 | enum Test {

--- a/crates/test-suite-enterprise/tests/ui/compilefail/captcha_not_identified.stderr
+++ b/crates/test-suite-enterprise/tests/ui/compilefail/captcha_not_identified.stderr
@@ -1,13 +1,12 @@
 error: Field containing hcaptcha not identified
 
-         = help: The field containing the hcaptcha response string must be identified with #[captcha]
+       help: The field containing the hcaptcha response string must be identified with #[captcha]
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/captcha_not_identified.rs:8:8
   |
 8 | struct Test {

--- a/crates/test-suite-enterprise/tests/ui/compilefail/not_a_struct.stderr
+++ b/crates/test-suite-enterprise/tests/ui/compilefail/not_a_struct.stderr
@@ -1,13 +1,12 @@
 error: Must derive on a struct
 
-         = help: This macro can only be implemented on a struct.
+       help: This macro can only be implemented on a struct.
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/not_a_struct.rs:9:6
   |
 9 | enum Test {

--- a/crates/test-suite-native-only/tests/ui/compilefail/captcha_not_identified.stderr
+++ b/crates/test-suite-native-only/tests/ui/compilefail/captcha_not_identified.stderr
@@ -1,13 +1,12 @@
 error: Field containing hcaptcha not identified
 
-         = help: The field containing the hcaptcha response string must be identified with #[captcha]
+       help: The field containing the hcaptcha response string must be identified with #[captcha]
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/captcha_not_identified.rs:8:8
   |
 8 | struct Test {

--- a/crates/test-suite-native-only/tests/ui/compilefail/not_a_struct.stderr
+++ b/crates/test-suite-native-only/tests/ui/compilefail/not_a_struct.stderr
@@ -1,13 +1,12 @@
 error: Must derive on a struct
 
-         = help: This macro can only be implemented on a struct.
+       help: This macro can only be implemented on a struct.
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/not_a_struct.rs:9:6
   |
 9 | enum Test {

--- a/crates/test-suite-no-default/tests/ui/compilefail/captcha_not_identified.stderr
+++ b/crates/test-suite-no-default/tests/ui/compilefail/captcha_not_identified.stderr
@@ -1,13 +1,12 @@
 error: Field containing hcaptcha not identified
 
-         = help: The field containing the hcaptcha response string must be identified with #[captcha]
+       help: The field containing the hcaptcha response string must be identified with #[captcha]
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/captcha_not_identified.rs:8:8
   |
 8 | struct Test {

--- a/crates/test-suite-no-default/tests/ui/compilefail/not_a_struct.stderr
+++ b/crates/test-suite-no-default/tests/ui/compilefail/not_a_struct.stderr
@@ -1,13 +1,12 @@
 error: Must derive on a struct
 
-         = help: This macro can only be implemented on a struct.
+       help: This macro can only be implemented on a struct.
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/not_a_struct.rs:9:6
   |
 9 | enum Test {

--- a/crates/test-suite-rustls-only/tests/ui/compilefail/captcha_not_identified.stderr
+++ b/crates/test-suite-rustls-only/tests/ui/compilefail/captcha_not_identified.stderr
@@ -1,13 +1,12 @@
 error: Field containing hcaptcha not identified
 
-         = help: The field containing the hcaptcha response string must be identified with #[captcha]
+       help: The field containing the hcaptcha response string must be identified with #[captcha]
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/captcha_not_identified.rs:8:8
   |
 8 | struct Test {

--- a/crates/test-suite-rustls-only/tests/ui/compilefail/not_a_struct.stderr
+++ b/crates/test-suite-rustls-only/tests/ui/compilefail/not_a_struct.stderr
@@ -1,13 +1,12 @@
 error: Must derive on a struct
 
-         = help: This macro can only be implemented on a struct.
+       help: This macro can only be implemented on a struct.
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/not_a_struct.rs:9:6
   |
 9 | enum Test {

--- a/crates/test-suite-trace/tests/ui/compilefail/captcha_not_identified.stderr
+++ b/crates/test-suite-trace/tests/ui/compilefail/captcha_not_identified.stderr
@@ -1,13 +1,12 @@
 error: Field containing hcaptcha not identified
 
-         = help: The field containing the hcaptcha response string must be identified with #[captcha]
+       help: The field containing the hcaptcha response string must be identified with #[captcha]
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/captcha_not_identified.rs:8:8
   |
 8 | struct Test {

--- a/crates/test-suite-trace/tests/ui/compilefail/not_a_struct.stderr
+++ b/crates/test-suite-trace/tests/ui/compilefail/not_a_struct.stderr
@@ -1,13 +1,12 @@
 error: Must derive on a struct
 
-         = help: This macro can only be implemented on a struct.
+       help: This macro can only be implemented on a struct.
 
                #[derive(Hcaptcha)]
                struct MyStruct {
                    #[captcha]
                    hcaptcha: String,
                }
-
  --> tests/ui/compilefail/not_a_struct.rs:9:6
   |
 9 | enum Test {


### PR DESCRIPTION
## Summary

Removes the unmaintained `proc-macro-error2` (RUSTSEC-2026-0173, repo archived) from `hcaptcha_derive` by switching to standard `syn` error handling. This **resolves** the advisory for hcaptcha-rs (proc-macro-error2 leaves the dependency tree entirely — not an audit ignore).

## Background

hcaptcha_derive is jerus-org's own crate, and it's the source of `proc-macro-error2` for several repos (hcaptcha-rs, and downstream `lambdas` / `wasmtime-tests` via `hcaptcha`). It used proc-macro-error2 only for the `#[proc_macro_error]` attribute and two `abort!{}` calls.

## Changes

- `get_struct_data` / `get_required_attribute` now return `Result<_, syn::Error>`; the derive entry point emits `e.to_compile_error()` instead of aborting.
- Dropped `proc-macro-error2` from the crate and workspace manifests (nothing else used it). Cargo.lock loses proc-macro-error2 and its sub-deps.

## Behaviour preserved

Invalid input still fails to compile with the same message + help + example. The trybuild `.stderr` snapshots were regenerated — the only change is the proc-macro-error `= help:` block becomes an inline `help:` line in the standard `syn` compile error. The unit test for a missing `#[captcha]` field now asserts a returned `Err` rather than a panic (a small improvement — no more panicking in the non-macro call path).

## Verification

`cargo test -p hcaptcha_derive` (unit + trybuild + doctests) passes; `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --all --check` clean; **`cargo audit` clean** (proc-macro-error2 no longer present).

## Follow-up

After release, bump `hcaptcha` in `lambdas` and `wasmtime-tests` to drop their (interim-ignored) exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Additional commits on this branch

- **Regenerated test-suite trybuild snapshots** — each `crates/test-suite-*` crate (default, enterprise, native-only, no-default, rustls-only, trace) has its own `tests/ui/compilefail/{captcha_not_identified,not_a_struct}.stderr` capturing the derive's error output, so all were regenerated for the new `syn` format (content unchanged: same message/help/example/span; only `= help:` becomes inline `help:`).
- **Bumped `jerus-org/circleci-toolkit@6.2.0 → 6.3.0`** (all 5 pipeline files) so the codecov upload step passes (codecov orb 6.0.0 fixes the org-wide `gpg: no valid OpenPGP data found` failure).
