### PR TITLE
fix(fuzz): update aws-lc-sys to 0.41.0

### DIFF
--- a/crates/hcaptcha/fuzz/Cargo.lock
+++ b/crates/hcaptcha/fuzz/Cargo.lock
@@ -33,9 +33,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -314,7 +314,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hcaptcha"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "async-trait",
  "hcaptcha_derive",
@@ -339,9 +339,8 @@ dependencies = [
 
 [[package]]
 name = "hcaptcha_derive"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -755,28 +754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
  "syn",
 ]
 


### PR DESCRIPTION
## Summary

Resolves the two **HIGH** Dependabot alerts in hcaptcha-rs, both in `aws-lc-sys` and both detected only in **`crates/hcaptcha/fuzz/Cargo.lock`** — the fuzz harness's separate lockfile, which had lagged behind the workspace lock (already on the patched `aws-lc-sys 0.40.0`).

| Alert | Advisory | Fixed in |
|---|---|---|
| X.509 Name Constraints Bypass via Wildcard/Unicode CN | [GHSA-394x-vwmw-crm3](https://github.com/advisories/GHSA-394x-vwmw-crm3) | aws-lc-sys 0.39.0 |
| CRL Distribution Point Scope Check Logic Error in AWS-LC | (AWS-LC) | recent aws-lc-sys |

## Change

`cargo update` in `crates/hcaptcha/fuzz`:
- `aws-lc-sys 0.38.0 → 0.41.0`, `aws-lc-rs 1.16.1 → 1.17.0` (pulled via `rustls` / `quinn-proto` / `rustls-webpki`).
- As a bonus the refresh also drops `proc-macro-error2` from the fuzz lock (it reached it via the local `hcaptcha_derive`, fixed in #1604).

Only `crates/hcaptcha/fuzz/Cargo.lock` changes. The vulnerable crate was confined to the fuzz harness (a dev/test target, not shipped); the published crates were unaffected, and the workspace lock was already patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)